### PR TITLE
parser: support generic types

### DIFF
--- a/crates/dash_middle/src/parser/types.rs
+++ b/crates/dash_middle/src/parser/types.rs
@@ -1,5 +1,9 @@
 use derive_more::Display;
 
+fn fmt_segments<'a>(s: &[TypeSegment<'a>]) -> String {
+    s.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(", ")
+}
+
 #[derive(Debug, Clone, Display, PartialEq, PartialOrd)]
 pub enum TypeSegment<'a> {
     #[display(fmt = "{_0} | {_1}")]
@@ -8,6 +12,8 @@ pub enum TypeSegment<'a> {
     Intersect(Box<TypeSegment<'a>>, Box<TypeSegment<'a>>),
     #[display(fmt = "{_0}[]")]
     Array(Box<TypeSegment<'a>>),
+    #[display(fmt = "{_0}<{}>", "fmt_segments(_1)")]
+    Generic(Box<TypeSegment<'a>>, Vec<TypeSegment<'a>>),
     Literal(LiteralType<'a>),
 }
 


### PR DESCRIPTION
Parses generic types
```js
let x: Foo<bar | baz, foo>;
```