### PR TITLE
Return strings in quotes regardless of depth

### DIFF
--- a/crates/dash_rt/js/inspect.js
+++ b/crates/dash_rt/js/inspect.js
@@ -17,11 +17,7 @@ const is = {
 
 function inner(value, depth) {
     if (is.string(value)) {
-        if (depth > 0) {
-            return '"' + value + '"';
-        } else {
-            return value;
-        }
+        return '"' + value + '"'; 
     }
 
     if (is.error(value)) {


### PR DESCRIPTION
Update inspect.js to always surround strings in quotes when returning, not just when depth is greater than 0