### PR TITLE
don't use recursion for executing functions in VM land

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ dependencies = [
  "dash_proc_macro",
  "dash_regex",
  "dash_typed_cfg",
+ "if_chain",
  "rustc-hash",
  "smallvec",
 ]
@@ -872,6 +873,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ dependencies = [
  "dash_proc_macro",
  "dash_regex",
  "dash_typed_cfg",
+ "rustc-hash",
  "smallvec",
 ]
 
@@ -1421,6 +1422,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/crates/dash_compiler/src/lib.rs
+++ b/crates/dash_compiler/src/lib.rs
@@ -1186,14 +1186,6 @@ impl<'a> Visitor<'a, Result<(), CompileError>> for FunctionCompiler<'a> {
             return Ok(());
         }
 
-        let has_this = if let Expr::PropertyAccess(p) = *target {
-            ib.visit_property_access_expr(p, true)?;
-            true
-        } else {
-            ib.accept_expr(*target)?;
-            false
-        };
-
         let argc = arguments
             .len()
             .try_into()
@@ -1202,6 +1194,14 @@ impl<'a> Visitor<'a, Result<(), CompileError>> for FunctionCompiler<'a> {
         for arg in arguments {
             ib.accept_expr(arg)?;
         }
+
+        let has_this = if let Expr::PropertyAccess(p) = *target {
+            ib.visit_property_access_expr(p, true)?;
+            true
+        } else {
+            ib.accept_expr(*target)?;
+            false
+        };
 
         let meta = FunctionCallMetadata::new_checked(argc, constructor_call, has_this)
             .ok_or(CompileError::ParameterLimitExceeded)?;

--- a/crates/dash_compiler/src/lib.rs
+++ b/crates/dash_compiler/src/lib.rs
@@ -1186,6 +1186,14 @@ impl<'a> Visitor<'a, Result<(), CompileError>> for FunctionCompiler<'a> {
             return Ok(());
         }
 
+        let has_this = if let Expr::PropertyAccess(p) = *target {
+            ib.visit_property_access_expr(p, true)?;
+            true
+        } else {
+            ib.accept_expr(*target)?;
+            false
+        };
+
         let argc = arguments
             .len()
             .try_into()
@@ -1194,14 +1202,6 @@ impl<'a> Visitor<'a, Result<(), CompileError>> for FunctionCompiler<'a> {
         for arg in arguments {
             ib.accept_expr(arg)?;
         }
-
-        let has_this = if let Expr::PropertyAccess(p) = *target {
-            ib.visit_property_access_expr(p, true)?;
-            true
-        } else {
-            ib.accept_expr(*target)?;
-            false
-        };
 
         let meta = FunctionCallMetadata::new_checked(argc, constructor_call, has_this)
             .ok_or(CompileError::ParameterLimitExceeded)?;

--- a/crates/dash_vm/Cargo.toml
+++ b/crates/dash_vm/Cargo.toml
@@ -23,6 +23,7 @@ bitflags = "1.3.2"
 smallvec = { version = "1.9.0", features = ["const_generics"] }
 ahash = "0.8.3"
 rustc-hash = "1.1.0"
+if_chain = "1.0.2"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/crates/dash_vm/Cargo.toml
+++ b/crates/dash_vm/Cargo.toml
@@ -22,6 +22,7 @@ dash_typed_cfg = { path = "../dash_typed_cfg", optional = true }
 bitflags = "1.3.2"
 smallvec = { version = "1.9.0", features = ["const_generics"] }
 ahash = "0.8.3"
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/crates/dash_vm/src/dispatch.rs
+++ b/crates/dash_vm/src/dispatch.rs
@@ -494,6 +494,9 @@ mod handlers {
         let is_constructor = meta.is_constructor_call();
         let has_this = meta.is_object_call();
 
+        let callee = cx.pop_stack();
+        let this = if has_this { cx.pop_stack() } else { Value::undefined() };
+
         let (args, refs) = {
             let argc = argc.into();
             let mut args = Vec::with_capacity(argc);
@@ -511,10 +514,6 @@ mod handlers {
 
             (args, refs)
         };
-
-        let callee = cx.pop_stack();
-
-        let this = if has_this { cx.pop_stack() } else { Value::undefined() };
 
         let mut scope = cx.scope();
         let scope_ref = &scope as *const LocalScope;

--- a/crates/dash_vm/src/external.rs
+++ b/crates/dash_vm/src/external.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::gc::handle::Handle;
 use crate::gc::trace::Trace;
@@ -7,7 +7,7 @@ use super::local::LocalScope;
 use super::value::object::Object;
 
 #[derive(Debug, Default)]
-pub struct Externals(HashMap<*const (), Vec<Handle<dyn Object>>>);
+pub struct Externals(FxHashMap<*const (), Vec<Handle<dyn Object>>>);
 
 unsafe impl Trace for Externals {
     fn trace(&self) {

--- a/crates/dash_vm/src/frame.rs
+++ b/crates/dash_vm/src/frame.rs
@@ -42,6 +42,8 @@ pub enum FrameState {
     Function {
         /// Whether the currently executing function is a constructor call
         is_constructor_call: bool,
+        /// Whether this frame is a flat function call
+        is_flat_call: bool,
     },
     /// Top level frame of a module
     Module(Exports),
@@ -100,7 +102,12 @@ pub struct Frame {
 }
 
 impl Frame {
-    pub fn from_function(this: Option<Value>, uf: &UserFunction, is_constructor_call: bool) -> Self {
+    pub fn from_function(
+        this: Option<Value>,
+        uf: &UserFunction,
+        is_constructor_call: bool,
+        is_flat_call: bool,
+    ) -> Self {
         let inner = uf.inner();
         Self {
             this,
@@ -109,7 +116,10 @@ impl Frame {
             ip: 0,
             sp: 0,
             extra_stack_space: inner.locals - uf.inner().params,
-            state: FrameState::Function { is_constructor_call },
+            state: FrameState::Function {
+                is_constructor_call,
+                is_flat_call,
+            },
             loop_counter: LoopCounterMap::default(),
         }
     }
@@ -159,6 +169,7 @@ impl Frame {
             extra_stack_space: cr.locals, /* - 0 params */
             state: FrameState::Function {
                 is_constructor_call: false,
+                is_flat_call: false,
             },
             loop_counter: LoopCounterMap::default(),
         }

--- a/crates/dash_vm/src/js_std/generator.rs
+++ b/crates/dash_vm/src/js_std/generator.rs
@@ -39,7 +39,7 @@ pub fn next(cx: CallContext) -> Result<Value, Value> {
         let current_sp = cx.scope.stack_size();
         cx.scope.try_extend_stack(old_stack)?;
 
-        let mut frame = Frame::from_function(None, function, false);
+        let mut frame = Frame::from_function(None, function, false, false);
         frame.set_ip(ip);
         frame.set_sp(current_sp);
 

--- a/crates/dash_vm/src/lib.rs
+++ b/crates/dash_vm/src/lib.rs
@@ -880,6 +880,8 @@ impl Vm {
             // Do not unwind further than we are allowed to. If the last try block is "outside" of
             // the frame that this execution context was instantiated in, then we can't jump there.
             if try_fp < max_fp {
+                // TODO: don't duplicate this code
+                self.frames.pop();
                 return Err(err);
             }
 
@@ -902,6 +904,18 @@ impl Vm {
         } else {
             self.frames.pop();
             Err(err)
+        }
+    }
+
+    /// Mostly useful for debugging
+    pub fn print_stack(&self) {
+        for (i, v) in self.stack.iter().enumerate() {
+            print!("{i}: ");
+            match v {
+                Value::Object(o) => println!("{:#?}", &**o),
+                Value::External(o) => println!("[[external]]: {:#?}", &*o.inner),
+                _ => println!("{v:?}")
+            }
         }
     }
 
@@ -958,7 +972,7 @@ impl Vm {
     }
 
     /// Executes a frame in this VM, without doing any sort of stack management
-    pub fn execute_frame_raw(&mut self, frame: Frame) -> Result<HandleResult, Value>
+    fn execute_frame_raw(&mut self, frame: Frame) -> Result<HandleResult, Value>
     {
         // TODO: if this fails, we MUST revert the stack management,
         // like reserving space for undefined values

--- a/crates/dash_vm/src/value/function/user.rs
+++ b/crates/dash_vm/src/value/function/user.rs
@@ -42,7 +42,7 @@ impl UserFunction {
 
         extend_stack_from_args(args, self.inner.params, scope, self.inner.rest_local.is_some());
 
-        let mut frame = Frame::from_function(Some(this), self, is_constructor_call);
+        let mut frame = Frame::from_function(Some(this), self, is_constructor_call, false);
         frame.set_sp(sp);
 
         scope.execute_frame(frame)

--- a/testrunner/differ.js
+++ b/testrunner/differ.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+const [, , pathBefore, pathAfter] = process.argv;
+
+if (!pathBefore || !pathAfter) throw new Error('Paths are missing');
+
+const R = /Some\("([^"]+)/g;
+const before = new Set(Array.from(fs.readFileSync(pathBefore, 'utf-8').matchAll(R)).map(x => x[1]));
+const now = Array.from(fs.readFileSync(pathAfter, 'utf-8').matchAll(R)).map(x => x[1]);
+
+for (const test of now) {
+    if (!before.has(test)) {
+        console.log(test)
+    }
+}

--- a/testrunner/src/cmd/run.rs
+++ b/testrunner/src/cmd/run.rs
@@ -8,9 +8,7 @@ use std::sync::Mutex;
 
 use clap::ArgMatches;
 use dash_vm::eval::EvalError;
-use dash_vm::local::LocalScope;
 use dash_vm::params::VmParams;
-use dash_vm::value::ops::abstractions::conversions::ValueConversion;
 use dash_vm::Vm;
 use once_cell::sync::Lazy;
 use serde::Deserialize;


### PR DESCRIPTION
For calls to user functions within user functions, we don't need recursion when a function is called. The vm already has all it needs to execute subfunctions without recursion through the VM value/frame stack.
From my (limited) amount of testing, this can have a pretty significant performance impact.