### PR TITLE
Fix small issues in stdlib

### DIFF
--- a/crates/dash_middle/src/interner.rs
+++ b/crates/dash_middle/src/interner.rs
@@ -76,6 +76,7 @@ pub mod sym {
                 super_: "super",
                 globalThis,
                 Infinity,
+                NegInfinity: "-Infinity",
                 NaN,
                 Math,
                 exp,

--- a/crates/dash_vm/src/js_std/number.rs
+++ b/crates/dash_vm/src/js_std/number.rs
@@ -2,7 +2,7 @@ use crate::throw;
 use crate::util::intern_f64;
 use crate::value::function::native::CallContext;
 use crate::value::ops::conversions::ValueConversion;
-use crate::value::primitive::{Number, MAX_SAFE_INTEGERF};
+use crate::value::primitive::{Number, MAX_SAFE_INTEGERF, MIN_SAFE_INTEGERF};
 use crate::value::{boxed, Value, ValueContext};
 
 pub fn constructor(cx: CallContext) -> Result<Value, Value> {
@@ -63,7 +63,7 @@ pub fn is_safe_integer(cx: CallContext) -> Result<Value, Value> {
         _ => return Ok(Value::Boolean(false)),
     };
 
-    Ok(Value::Boolean(*num < MAX_SAFE_INTEGERF))
+    Ok(Value::Boolean(*num <= MAX_SAFE_INTEGERF && *num >= MIN_SAFE_INTEGERF))
 }
 
 pub fn to_fixed(cx: CallContext) -> Result<Value, Value> {

--- a/crates/dash_vm/src/js_std/number.rs
+++ b/crates/dash_vm/src/js_std/number.rs
@@ -77,6 +77,14 @@ pub fn to_fixed(cx: CallContext) -> Result<Value, Value> {
         .map(|n| n as usize)
         .unwrap_or(0);
 
+    if decimals > 100 {
+        throw!(
+            cx.scope,
+            RangeError,
+            "toFixed() fractional digits must be between 0 and 100 inclusive"
+        )
+    };
+
     let re = format!("{num:.decimals$}");
 
     Ok(Value::String(cx.scope.intern(re.as_ref()).into()))

--- a/crates/dash_vm/src/util.rs
+++ b/crates/dash_vm/src/util.rs
@@ -31,7 +31,8 @@ pub fn intern_f64(sc: &mut LocalScope, n: f64) -> Symbol {
     }
 
     match n.classify() {
-        FpCategory::Infinite => sym::Infinity,
+        FpCategory::Infinite if n.is_sign_positive() => sym::Infinity,
+        FpCategory::Infinite => sym::NegInfinity,
         FpCategory::Nan => sym::NaN,
         _ if n >= 1e21f64 || n <= -1e21f64 => {
             let mut digits = 0;


### PR DESCRIPTION
Fixes a few small issues in the js stdlib, mainly:
- Range checking on `Number#isSafeInteger`
- Interning representation of negative infinities,
- `Number#toFixed` not limiting the number of decimal places between 0 and 100, as [per spec](https://tc39.es/ecma262/#sec-number.prototype.tofixed) (point 5).